### PR TITLE
Ansible 2.2 correction to with_subelements

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,7 +61,7 @@
 - name: Create the network configuration file for slave in the bond devices
   template: src=bond_slave_{{ ansible_os_family }}.j2 dest={{ net_path }}/ifcfg-{{ item.1 }}
   with_subelements:
-   - network_bond_interfaces
+   - "{{network_bond_interfaces}}"
    - bond_slaves
   when: network_bond_interfaces is defined
   register: bond_port_result
@@ -101,7 +101,7 @@
 - name: Create the network configuration file for port on the bridge devices
   lineinfile: dest={{ net_path }}/ifcfg-{{ item.1 }} regexp='^BRIDGE=' line=BRIDGE={{ item.0.device }}
   with_subelements:
-    - network_bridge_interfaces
+    - "{{network_bridge_interfaces}}"
     - ports
   when: network_bridge_interfaces is defined
   register: bridge_port_result


### PR DESCRIPTION
The role did not work with ansible 2.2 as quote plus curly brackets are now mandatory for the first item of with_subelements.