### PR TITLE
Fix to support bond VLAN attached to bridge

### DIFF
--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -50,3 +50,7 @@ DEFROUTE={{ item.defroute }}
 {% if item.mtu is defined %}
 MTU={{ item.mtu }}
 {% endif %}
+
+{% if item.bridge is defined %}
+BRIDGE={{ item.bridge }}
+{% endif %}


### PR DESCRIPTION
Added possibility to define bridge name in interface configuration.
This is needed to attach bonded VLAN interface to a bridge.

I have done this only for RedHat template as right now I don't have time to test the same in Debian variant.