### PR TITLE
Add some minor improvements for RHEL

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
    - restart network
 
 - name: Write configuration files for rhel route configuration
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: "{{ network_ether_interfaces }}"
   when: network_ether_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
 
@@ -52,7 +52,7 @@
   when: bond_result|changed
 
 - name: Write configuration files for route configuration
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: "{{ network_bond_interfaces }}"
   when: network_bond_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:
@@ -77,7 +77,7 @@
    - restart network
 
 - name: Write configuration files for rhel route configuration with vlan
-  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }} 
+  template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: "{{ network_vlan_interfaces }}"
   when: network_vlan_interfaces is defined and item.route is defined and ansible_os_family == 'RedHat'
   notify:

--- a/templates/bond_Debian.j2
+++ b/templates/bond_Debian.j2
@@ -10,35 +10,34 @@ netmask {{ item.netmask }}
 {% if item.gateway is defined %}
 gateway {{ item.gateway }}
 {% endif %}
-{% if item.bond_mode is defined %}        
+{% if item.bond_mode is defined %}
 bond-mode {{ item.bond_mode }}
 {% endif %}
 bond-miimon {{ item.bond_miimon|default(100) }}
-{% if item.bond_slaves is defined and item.bond_mode == 'active-backup' %}        
+{% if item.bond_slaves is defined and item.bond_mode == 'active-backup' %}
 bond-slaves none
 {% endif %}
-{% if item.bond_slaves is defined and item.bond_mode == '802.3ad' %}        
+{% if item.bond_slaves is defined and item.bond_mode == '802.3ad' %}
 bond-slaves {{ item.bond_slaves|join(' ') }}
 {% endif %}
 {% endif %}
 
 {% if item.bootproto == 'dhcp' %}
 iface {{ item.device }}  inet dhcp
-{% if item.bond_mode is defined %}        
+{% if item.bond_mode is defined %}
 bond-mode {{ item.bond_mode }}
 {% endif %}
 bond-miimon {{ item.bond_miimon|default(100) }}
-{% if item.bond_slaves is defined and item.bond_mode == 'active-backup' %}        
+{% if item.bond_slaves is defined and item.bond_mode == 'active-backup' %}
 bond-slaves none
 {% endif %}
-{% if item.bond_slaves is defined and item.bond_mode == '802.3ad' %}        
+{% if item.bond_slaves is defined and item.bond_mode == '802.3ad' %}
 bond-slaves {{ item.bond_slaves|join(' ') }}
 {% endif %}
 {% endif %}
 
 {% if item.route is defined %}
 {% for i in item.route %}
-up route add -net {{ i.network }}  netmask {{ i.netmask }} gw {{ i.gateway }} dev {{ item.device }}
+up route add -net {{ i.network }} netmask {{ i.netmask }} gw {{ i.gateway }} dev {{ item.device }}
 {% endfor %}
 {% endif %}
-

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -1,4 +1,3 @@
-
 {% if item.bootproto != 'dhcp' %}
 DEVICE={{ item.device }}
 USERCTL=no

--- a/templates/bridge_Debian.j2
+++ b/templates/bridge_Debian.j2
@@ -10,27 +10,26 @@ netmask {{ item.netmask }}
 {% if item.gateway is defined %}
 gateway {{ item.gateway }}
 {% endif %}
-{% if item.ports is defined %}        
+{% if item.ports is defined %}
 bridge_ports {{ item.ports|join(' ') }}
 {% endif %}
-{% if item.stp is defined %}        
+{% if item.stp is defined %}
 bridge_stp {{ item.stp }}
 {% endif %}
 {% endif %}
 
 {% if item.bootproto == 'dhcp' %}
 iface {{ item.device }}  inet dhcp
-{% if item.ports is defined %}        
+{% if item.ports is defined %}
 bridge_ports {{ item.port }}
 {% endif %}
-{% if item.stp is defined %}        
+{% if item.stp is defined %}
 bridge_stp {{ item.stp }}
 {% endif %}
 {% endif %}
 
 {% if item.route is defined %}
 {% for i in item.route %}
-up route add -net {{ i.network }}  netmask {{ i.netmask }} gw {{ i.gateway }} dev {{ item.device }}
+up route add -net {{ i.network }} netmask {{ i.netmask }} gw {{ i.gateway }} dev {{ item.device }}
 {% endfor %}
 {% endif %}
-

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -1,21 +1,20 @@
-
 {% if item.bootproto == 'static' %}
 DEVICE={{ item.device }}
 TYPE=Bridge
 BOOTPROTO=none
-{% if item.stp is defined %}
+{% if item.stp is defined -%}
 STP={{ item.stp }}
 {% endif %}
-{% if item.address is defined %}
+{%- if item.address is defined -%}
 IPADDR={{ item.address }}
 {% endif %}
-{% if item.onboot is defined %}
+{%- if item.onboot is defined -%}
 ONBOOT={{ item.onboot }}
 {% endif %}
-{% if item.netmask is defined %}
+{%- if item.netmask is defined -%}
 NETMASK={{ item.netmask }}
 {% endif %}
-{% if item.gateway is defined %}
+{%- if item.gateway is defined -%}
 GATEWAY={{ item.gateway }}
 {% endif %}
 {% endif %}
@@ -24,16 +23,16 @@ GATEWAY={{ item.gateway }}
 DEVICE={{ item.device }}
 TYPE=bridge
 BOOTPROTO=dhcp
-{% if item.stp is defined %}
+{% if item.stp is defined -%}
 STP={{ item.stp }}
 {% endif %}
 {% endif %}
 
-{% if item.nm_controlled is defined %}
+{%- if item.nm_controlled is defined -%}
 NM_CONTROLLED={{ item.nm_controlled }}
 {% endif %}
 
-{% if item.ipv6_address is defined %}
+{%- if item.ipv6_address is defined -%}
 IPV6INIT="yes"
 IPV6_AUTOCONF="yes"
 IPV6_DEFROUTE="yes"
@@ -44,15 +43,14 @@ IPV6_PEERROUTES="yes"
 IPV6_PRIVACY="no"
 IPV6ADDR={{ item.ipv6_address }}
 {% endif %}
-{% if item.ipv6_gateway is defined %}
+{% if item.ipv6_gateway is defined -%}
 IPV6_DEFAULTGW="{{ item.ipv6_gateway }}"
 {% endif %}
 
-
-{% if item.defroute is defined %}
+{%- if item.defroute is defined -%}
 DEFROUTE={{ item.defroute }}
 {% endif %}
 
-{% if item.mtu is defined %}
+{%- if item.mtu is defined -%}
 MTU={{ item.mtu }}
 {% endif %}

--- a/templates/bridge_port_Debian.j2
+++ b/templates/bridge_port_Debian.j2
@@ -1,2 +1,2 @@
 auto {{ item.1 }}
-iface {{ item.1 }}  inet manual
+iface {{ item.1 }} inet manual

--- a/templates/bridge_port_RedHat.j2
+++ b/templates/bridge_port_RedHat.j2
@@ -1,6 +1,4 @@
-
 DEVICE={{ item.1 }}
 TYPE=Ethernet
 BOOTPROTO=none
 BRIDGE={{ item.0.device }}
-

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -1,4 +1,4 @@
-{% if item.bootproto == 'static' %}
+{% if item.bootproto == 'static' or item.bootproto == 'none' %}
 DEVICE={{ item.device }}
 BOOTPROTO=none
 {% if item.address is defined -%}
@@ -15,6 +15,9 @@ GATEWAY={{ item.gateway }}
 {% endif %}
 {%- if item.vlan is defined -%}
 VLAN=yes
+{% endif %}
+{%- if item.bridge is defined -%}
+BRIDGE={{ item.bridge }}
 {% endif %}
 {% endif %}
 

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -1,20 +1,19 @@
-
 {% if item.bootproto == 'static' %}
 DEVICE={{ item.device }}
 BOOTPROTO=none
-{% if item.address is defined %}
+{% if item.address is defined -%}
 IPADDR={{ item.address }}
 {% endif %}
-{% if item.onboot is defined %}
+{%- if item.onboot is defined -%}
 ONBOOT={{ item.onboot }}
 {% endif %}
-{% if item.netmask is defined %}
+{%- if item.netmask is defined -%}
 NETMASK={{ item.netmask }}
 {% endif %}
-{% if item.gateway is defined %}
+{%- if item.gateway is defined -%}
 GATEWAY={{ item.gateway }}
 {% endif %}
-{% if item.vlan is defined %}
+{%- if item.vlan is defined -%}
 VLAN=yes
 {% endif %}
 {% endif %}
@@ -24,11 +23,11 @@ DEVICE={{ item.device }}
 BOOTPROTO=dhcp
 {% endif %}
 
-{% if item.nm_controlled is defined %}
+{%- if item.nm_controlled is defined -%}
 NM_CONTROLLED={{ item.nm_controlled }}
 {% endif %}
 
-{% if item.ipv6_address is defined %}
+{%- if item.ipv6_address is defined -%}
 IPV6INIT="yes"
 IPV6_AUTOCONF="yes"
 IPV6_DEFROUTE="yes"
@@ -39,14 +38,14 @@ IPV6_PEERROUTES="yes"
 IPV6_PRIVACY="no"
 IPV6ADDR={{ item.ipv6_address }}
 {% endif %}
-{% if item.ipv6_gateway is defined %}
+{% if item.ipv6_gateway is defined -%}
 IPV6_DEFAULTGW="{{ item.ipv6_gateway }}"
 {% endif %}
 
-{% if item.defroute is defined %}
+{%- if item.defroute is defined -%}
 DEFROUTE={{ item.defroute }}
 {% endif %}
 
-{% if item.mtu is defined %}
+{%- if item.mtu is defined -%}
 MTU={{ item.mtu }}
 {% endif %}

--- a/templates/route_Debian.j2
+++ b/templates/route_Debian.j2
@@ -1,4 +1,4 @@
 {% for i in item.route %}
-up route add -net {{ i.network }}  netmask {{ i.netmask }} gw {{ i.gateway }} dev {{ item.device }} 
+up route add -net {{ i.network }} netmask {{ i.netmask }} gw {{ i.gateway }} dev {{ item.device }}
 {% endfor %}
 

--- a/templates/route_RedHat.j2
+++ b/templates/route_RedHat.j2
@@ -5,4 +5,3 @@ NETMASK{{ loop.index - 1 }}={{ i.netmask }}
 GATEWAY{{ loop.index - 1 }}={{ i.gateway }}
 {% endif %}
 {% endfor %}
-


### PR DESCRIPTION
I think having either 'static' or 'none' would make more sense. I also added several minus signs to strip trailing whitespace and newlines and the ability to point an interface to a bridge interface. I'm not using all the templates, so I only added to the ones that I used.