### PR TITLE
Allow setting bonding module options and optionally configure nozeroconf on RedHat ifcfg files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ machines. The role can be used to configure:
 - Bonded interfaces
 - VLAN tagged interfaces
 - Network routes
+- Bonding Kernel Module parameters
 
 Requirements
 ------------
@@ -91,13 +92,16 @@ define static routes and a gateway.
 Note: Routes can also be added for this interface in the same way routes are
 added for ethernet interfaces.
 
-3) Configure a bond interface with an "active-backup" slave configuration.
+3) Configure a bond-ext interface with an "active-backup" slave configuration.
+Also set max_bonds=0 parameter to the bonding kernel module. Preventing
+an empty bond0 from being created.
 ```
     - hosts: myhost
       roles:
         - role: network
+          network_extra_bonding_module_options: "max_bonds=0"
           network_bond_interfaces:
-            - device: bond0
+            - device: bond-ext
               address: 192.168.10.128
               netmask: 255.255.255.0
               bootproto: static
@@ -124,7 +128,9 @@ address obtained via DHCP.
               bond_slaves: [eth1, eth2]
 ```
 
-5) Configure a VLAN interface with the vlan tag 2 for an ethernet interface
+5) Configure a VLAN interface with the vlan tag 2 for an ethernet interface 
+and set nozeroconf to True (no 169.254.0.0/16 link local address).
+
 ```
     - hosts: myhost
       roles:
@@ -132,6 +138,7 @@ address obtained via DHCP.
           network_ether_interfaces:
             - device: eth1
               bootproto: static
+              nozeroconf: True
               address: 192.168.10.18
               netmask: 255.255.255.0
               gateway: 192.168.10.1
@@ -160,6 +167,7 @@ Describe your network configuration for each host in host vars:
     network_ether_interfaces:
            - device: eth1
              bootproto: static
+             nozeroconf: True
              address: 192.168.10.18
              netmask: 255.255.255.0
              gateway: 192.168.10.1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,5 @@ network_bond_interfaces: []
 network_vlan_interfaces: []
 network_check_packages: true
 network_allow_service_restart: true
+bond_modules_path: "/etc/modprobe.d"
+network_extra_bonding_module_options: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,6 +54,10 @@
   notify:
    - restart network
 
+- name: template in bonding.conf module settings
+  template: src=bonding.conf.j2 dest={{ bond_modules_path}}/bonding.conf
+  when: network_bond_interfaces is defined and network_extra_bonding_module_options != ""
+
 - name: Make sure the bonding module is loaded
   modprobe: name=bonding state=present
   when: bond_result is changed

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -36,8 +36,8 @@ DEFROUTE={{ item.defroute }}
 {% if item.mtu is defined %}
 MTU={{ item.mtu }}
 {% endif %}
-{%- if item.zeroconf is defined -%}
-NOZEROCONF={{ item.zeroconf }}
+{%- if item.nozeroconf is defined -%}
+NOZEROCONF={{ item.nozeroconf }}
 {% endif %}
 
 {% if item.bonding_master is defined %}

--- a/templates/bond_RedHat.j2
+++ b/templates/bond_RedHat.j2
@@ -36,6 +36,9 @@ DEFROUTE={{ item.defroute }}
 {% if item.mtu is defined %}
 MTU={{ item.mtu }}
 {% endif %}
+{%- if item.zeroconf is defined -%}
+NOZEROCONF={{ item.zeroconf }}
+{% endif %}
 
 {% if item.bonding_master is defined %}
 BONDING_MASTER={{ item.bonding_master }}

--- a/templates/bonding.conf.j2
+++ b/templates/bonding.conf.j2
@@ -1,1 +1,2 @@
-options bonding
+# {{ ansible_managed }}
+options bonding {{ network_extra_bonding_module_options }}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -54,3 +54,6 @@ DEFROUTE={{ item.defroute }}
 {%- if item.mtu is defined -%}
 MTU={{ item.mtu }}
 {% endif %}
+{%- if item.zeroconf is defined -%}
+NOZEROCONF={{ item.zeroconf }}
+{% endif %}

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -54,6 +54,6 @@ DEFROUTE={{ item.defroute }}
 {%- if item.mtu is defined -%}
 MTU={{ item.mtu }}
 {% endif %}
-{%- if item.zeroconf is defined -%}
-NOZEROCONF={{ item.zeroconf }}
+{%- if item.nozeroconf is defined -%}
+NOZEROCONF={{ item.nozeroconf }}
 {% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -52,3 +52,6 @@ DEFROUTE={{ item.defroute }}
 {%- if item.mtu is defined -%}
 MTU={{ item.mtu }}
 {% endif %}
+{%- if item.zeroconf is defined -%}
+NOZEROCONF={{ item.zeroconf }}
+{% endif %}

--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -52,6 +52,6 @@ DEFROUTE={{ item.defroute }}
 {%- if item.mtu is defined -%}
 MTU={{ item.mtu }}
 {% endif %}
-{%- if item.zeroconf is defined -%}
-NOZEROCONF={{ item.zeroconf }}
+{%- if item.nozeroconf is defined -%}
+NOZEROCONF={{ item.nozeroconf }}
 {% endif %}


### PR DESCRIPTION
 - new variable: network_extra_bonding_module_options:
   - by setting it to something other than "" the template task will run. 
   - As an example ( credits to @Aegil ):
     - Could be nice in case you want to have bonds not called bond0, and skip getting an empty bond0 -  try out 
     - network_extra_bonding_module_options: "max_bonds=0"
 - by setting nozeroconf: True you don't get the IPv4 link local 169.254.0.0/16 address on that interface.