### PR TITLE
Allow setting BRIDGING_OPTS on EL bridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ define static routes and a gateway.
 ```
 
 2) Configure a bridge interface with multiple NIcs added to the bridge.
+Also set bridging_opts, an example in case you need multicasting.
 ```
     - hosts: myhost
       roles:
@@ -82,6 +83,7 @@ define static routes and a gateway.
               gateway: 192.168.10.1
               bootproto: static
               stp: "on"
+              bridging_opts: "multicast_snooping=1 multicast_querier=1"
           network_ether_interfaces:
             - device: eth1
               bootproto: none

--- a/templates/bridge_RedHat.j2
+++ b/templates/bridge_RedHat.j2
@@ -57,3 +57,6 @@ MTU={{ item.mtu }}
 {%- if item.nozeroconf is defined -%}
 NOZEROCONF={{ item.nozeroconf }}
 {% endif %}
+{%- if item.bridging_opts is defined -%}
+BRIDGING_OPTS="{{ item.bridging_opts }}"
+{% endif %}


### PR DESCRIPTION
Tested by running this role and --diff against a hypervisor of ours without any VMs that actually use the interface I changed :)

Found this setting by 
```
$ grep "multicast" /etc/sysconfig/network-scripts/*
```

Tested with only these two settings:

 - multicast_snooping
 - multicast_querier

Tested manually by:

<pre>
$ cat /sys/class/net/bridge1/bridge/multicast_querier
0
$ cat /sys/class/net/bridge1/bridge/multicast_snooping
0
</pre>

Then setting them to 1

<pre>
$ grep BRIDGING_OPTS /etc/sysconfig/network-scripts/ifcfg-bridge1
BRIDGING_OPTS="multicast_snooping=1 multicast_querier=1"
</pre>

Then ifdown/ifup bridge1 and the values in /sys/class now return 1

 - #CCCP-2484