### PR TITLE
Fewer empty newlines VLANs without bond_slave_vlan

### DIFF
--- a/templates/bond_slave_RedHat.j2
+++ b/templates/bond_slave_RedHat.j2
@@ -5,14 +5,13 @@ ONBOOT=yes
 SLAVE=yes
 USERCTL=no
 
-{% if item.0.bond_slave_vlan is defined %}
-VLAN=yes
-{% endif %}
-
 {% if item.nm_controlled is defined %}
 NM_CONTROLLED={{ item.nm_controlled }}
 {% endif %}
 
 {% if item.defroute is defined %}
 DEFROUTE={{ item.defroute }}
+{% endif %}
+{%- if item.0.bond_slave_vlan is defined -%}
+VLAN=yes
 {% endif %}


### PR DESCRIPTION
Moving this new bond slave parameter to the bottom of the template file
to prevent adding a newline to every interface.

I have looked at this before and probably we can't use {%- -%} everywhere,
for example in the jinja2 for-loops (inside templates). But at some
point it could be nice to stop creating empty newlines..

On all my servers which has VLAN interfaces without any bond_slave_vlan
in the configuration I see this when running ansible with --diff:

<pre>
TASK [ansible-role-network-interface : Create the network configuration
file for slave in the bond devices]
**************************************************************
--- before: /etc/sysconfig/network-scripts/ifcfg-p1p1
+++ after:
/home/yepthatsme/.ansible/tmp/ansible-local-27992FIt2Sb/tmpn1bL6i/bond_slave_RedHat.j2
@@ -6,3 +6,4 @@
 USERCTL=no

+
</pre>

After this change the file is not modified and also the network service
is not restarted needlessly.