### PR TITLE
Allow manual VLAN and bridge provisioning

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,6 @@ network_allow_service_restart: true
 bond_modules_path: "/etc/modprobe.d"
 network_extra_bonding_module_options: ""
 network_ip_route_ephemeral: false
+network_bridge_ephemeral: false
+network_vlan_ephemeral: false
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,4 +11,3 @@ network_extra_bonding_module_options: ""
 network_ip_route_ephemeral: false
 network_bridge_ephemeral: false
 network_vlan_ephemeral: false
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -110,6 +110,14 @@
   notify:
    - restart network
 
+- name: Add vlan interfaces manually if network_vlan_ephemeral is True
+  command: "ip link add link {{ item.device.split(".")[0] }} name {{ item.device }} type vlan id {{ item.device.split(".")[1] }}"
+  with_items: "{{ network_vlan_interfaces }}"
+  when: network_vlan_interfaces is defined and ansible_os_family == 'RedHat' and network_vlan_ephemeral
+  register: reg_network_vlan
+  failed_when: reg_network_vlan.rc|int != 0 and reg_network_vlan.rc|int != 2
+  changed_when: reg_network_vlan.rc|int == 0
+
 - name: Write configuration files for rhel route configuration with vlan
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: "{{ network_vlan_interfaces }}"
@@ -132,6 +140,14 @@
   register: bridge_result
   notify:
    - restart network
+
+- name: Add bridges manually if network_bridge_ephemeral is True
+  command: "brctl addbr {{ item.device }}"
+  with_items: "{{ network_bridge_interfaces }}"
+  when: network_bridge_interfaces is defined and ansible_os_family == 'RedHat' and network_bridge_ephemeral
+  register: reg_network_bridge
+  failed_when: reg_network_bridge.rc|int != 0 and reg_network_bridge.rc|int != 2
+  changed_when: reg_network_bridge.rc|int == 0
 
 - name: Write configuration files for rhel route configuration
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -113,7 +113,7 @@
 - name: Add vlan interfaces manually if network_vlan_ephemeral is True
   command: "ip link add link {{ item.device.split('.')[0] }} name {{ item.device }} type vlan id {{ item.device.split('.')[1] }}"
   args:
-    creates: "/sys/class/net/{{ item.device }}"
+    creates: "/sys/devices/virtual/net/{{ item.device }}"
   with_items: "{{ network_vlan_interfaces }}"
   when: network_vlan_interfaces is defined and ansible_os_family == 'RedHat' and network_vlan_ephemeral
   register: reg_network_vlan
@@ -146,7 +146,7 @@
 - name: Add bridges manually if network_bridge_ephemeral is True
   command: "brctl addbr {{ item.device }}"
   args:
-    creates: "/sys/class/net/{{ item.device }}"
+    creates: "/sys/devices/virtual/net/{{ item.device }}"
   with_items: "{{ network_bridge_interfaces }}"
   when: network_bridge_interfaces is defined and ansible_os_family == 'RedHat' and network_bridge_ephemeral
   register: reg_network_bridge
@@ -155,6 +155,8 @@
 
 - name: Plug VLAN interfaces to bridges manually if network_bridge_ephemeral and network_vlan_ephemeral are True
   command: "brctl addif {{ item.bridge }} {{ item.device }}"
+  args:
+    creates: "/sys/devices/virtual/net/{{ item.bridge }}/lower_{{ item.device }}"
   with_items: "{{ network_vlan_interfaces }}"
   when: network_bridge_interfaces is defined and ansible_os_family == 'RedHat' and network_bridge_ephemeral and network_vlan_ephemeral
   register: reg_network_bridge_vlan

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -112,6 +112,8 @@
 
 - name: Add vlan interfaces manually if network_vlan_ephemeral is True
   command: "ip link add link {{ item.device.split('.')[0] }} name {{ item.device }} type vlan id {{ item.device.split('.')[1] }}"
+  args:
+    creates: "/sys/class/net/{{ item.device }}"
   with_items: "{{ network_vlan_interfaces }}"
   when: network_vlan_interfaces is defined and ansible_os_family == 'RedHat' and network_vlan_ephemeral
   register: reg_network_vlan

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -120,6 +120,14 @@
   failed_when: reg_network_vlan.rc|int != 0 and reg_network_vlan.rc|int != 2
   changed_when: reg_network_vlan.rc|int == 0
 
+- name: Set MTU manually on vlan interfaces if network_vlan_ephemeral is True and the interface parameters include mtu
+  command: "ip link set mtu {{ item.mtu }} {{ item.device }}"
+  with_items: "{{ network_vlan_interfaces }}"
+  when: network_vlan_interfaces is defined and ansible_os_family == 'RedHat' and network_vlan_ephemeral and item.mtu is defined
+  register: reg_network_vlan
+  failed_when: reg_network_vlan.rc|int != 0 and reg_network_vlan.rc|int != 2
+  changed_when: reg_network_vlan.rc|int == 0
+
 - name: Write configuration files for rhel route configuration with vlan
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: "{{ network_vlan_interfaces }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -143,6 +143,8 @@
 
 - name: Add bridges manually if network_bridge_ephemeral is True
   command: "brctl addbr {{ item.device }}"
+  args:
+    creates: "/sys/class/net/{{ item.device }}"
   with_items: "{{ network_bridge_interfaces }}"
   when: network_bridge_interfaces is defined and ansible_os_family == 'RedHat' and network_bridge_ephemeral
   register: reg_network_bridge

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -153,6 +153,14 @@
   failed_when: reg_network_bridge.rc|int != 0 and reg_network_bridge.rc|int != 2
   changed_when: reg_network_bridge.rc|int == 0
 
+- name: Plug VLAN interfaces to bridges manually if network_bridge_ephemeral and network_vlan_ephemeral are True
+  command: "brctl addif {{ item.bridge }} {{ item.device }}"
+  with_items: "{{ network_vlan_interfaces }}"
+  when: network_bridge_interfaces is defined and ansible_os_family == 'RedHat' and network_bridge_ephemeral and network_vlan_ephemeral
+  register: reg_network_bridge_vlan
+  failed_when: reg_network_bridge_vlan.rc|int != 0 and reg_network_bridge_vlan.rc|int != 2
+  changed_when: reg_network_bridge_vlan.rc|int == 0
+
 - name: Write configuration files for rhel route configuration
   template: src=route_{{ ansible_os_family }}.j2 dest={{ net_path }}/route-{{ item.device }}
   with_items: "{{ network_bridge_interfaces }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,7 +111,7 @@
    - restart network
 
 - name: Add vlan interfaces manually if network_vlan_ephemeral is True
-  command: "ip link add link {{ item.device.split(".")[0] }} name {{ item.device }} type vlan id {{ item.device.split(".")[1] }}"
+  command: "ip link add link {{ item.device.split('.')[0] }} name {{ item.device }} type vlan id {{ item.device.split('.')[1] }}"
   with_items: "{{ network_vlan_interfaces }}"
   when: network_vlan_interfaces is defined and ansible_os_family == 'RedHat' and network_vlan_ephemeral
   register: reg_network_vlan


### PR DESCRIPTION
Introduce two new variables network_bridge_ephemeral and
network_vlan_ephemeral. If set, the corresponding network elements
will be added with manual actions in addition to adding them into 
configuration files.