### PR TITLE
Make sure that all notifies are executed at the end of the role

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -209,3 +209,6 @@
   register: reg_network_iproute
   failed_when: reg_network_iproute.rc|int != 0 and reg_network_iproute.rc|int != 2
   changed_when: reg_network_iproute.rc|int == 0
+
+- name: Make sure that are handlers are done before ending the role
+  meta: flush_handlers


### PR DESCRIPTION
Handlers are done at the end of a _play_ not role or playbook.
Basically I must have the network configured correctly before I can configure my web service.
https://docs.ansible.com/ansible/latest/user_guide/playbooks_intro.html#handlers-running-operations-on-change
