### PR TITLE
Separate IPv6 gateway related stuff if not needed

### DIFF
--- a/templates/ethernet_RedHat.j2
+++ b/templates/ethernet_RedHat.j2
@@ -33,15 +33,15 @@ NM_CONTROLLED={{ item.nm_controlled }}
 {%- if item.ipv6_address is defined -%}
 IPV6INIT="yes"
 IPV6_AUTOCONF="yes"
-IPV6_DEFROUTE="yes"
 IPV6_FAILURE_FATAL="no"
-IPV6_FORWARDING="yes"
-IPV6_PEERDNS="yes"
-IPV6_PEERROUTES="yes"
 IPV6_PRIVACY="no"
 IPV6ADDR={{ item.ipv6_address }}
 {% endif %}
 {%- if item.ipv6_gateway is defined -%}
+IPV6_FORWARDING="yes"
+IPV6_PEERDNS="yes"
+IPV6_PEERROUTES="yes"
+IPV6_DEFROUTE="yes"
 IPV6_DEFAULTGW="{{ item.ipv6_gateway }}"
 {% endif %}
 


### PR DESCRIPTION
A node might not need gateway related stuff in the interface configuration if the node is not acting as gateway.

CCCP-4087