### PR TITLE
Make role CentOS-8 compatible

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,16 +38,6 @@
      packages:  "{{ network_pkgs }}"
   environment: env
   when: ansible_os_family == 'Debian'
-  
-- name: Prevent NetworkManager from managing resolv.conf
-  copy:
-    dest: "/etc/NetworkManager/conf.d/90-dns-none.conf"
-    content: |
-      [main]
-      dns=none
-  when: os_centos8
-  notify:
-   - restart network
 
 - name: Make sure the include line is there in interfaces file
   lineinfile: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,16 @@
      packages:  "{{ network_pkgs }}"
   environment: env
   when: ansible_os_family == 'Debian'
+  
+- name: Prevent NetworkManager from managing resolv.conf
+  copy:
+    dest: "/etc/NetworkManager/conf.d/90-dns-none.conf"
+    content: |
+      [main]
+      dns=none
+  when: os_centos8
+  notify:
+   - restart network
 
 - name: Make sure the include line is there in interfaces file
   lineinfile: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,17 +11,17 @@
 
 - name: Check if we are in CentOS 8
   set_fact:
-    os_centos8: ansible_facts['distribution'] == 'CentOS' and ansible_facts['distribution_major_version'] == '8'
+    os_centos8: "{{ ansible_facts['distribution'] == 'CentOS' and ansible_facts['distribution_major_version'] == '8' }}"
 
 - name: Install prerequisites for CentOS 8
   yum:
-    name: epel-release network-scripts
+    name: epel-release,network-scripts
     state: latest
   when: os_centos8
 
 - name: Adjust vars in case of CentOS 8
   set_fact:
-    network_pkgs: network_pkgs_centos8
+    network_pkgs: "{{ network_pkgs_centos8 }}"
   when: os_centos8
 
 - name: Install the required  packages in Redhat derivatives

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,21 @@
 - name: Add the OS specific varibles
   include_vars: "{{ ansible_os_family }}.yml"
 
+- name: Check if we are in CentOS 8
+  set_fact:
+    os_centos8: ansible_facts['distribution'] == 'CentOS' and ansible_facts['distribution_major_version'] == '8'
+
+- name: Install prerequisites for CentOS 8
+  yum:
+    name: epel-release network-scripts
+    state: latest
+  when: os_centos8
+
+- name: Adjust vars in case of CentOS 8
+  set_fact:
+    network_pkgs: network_pkgs_centos8
+  when: os_centos8
+
 - name: Install the required  packages in Redhat derivatives
   yum:
     name: "{{ network_pkgs }}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,10 @@
 ---
 network_pkgs:
+  - libselinux-python
+  - bridge-utils
+  - iputils
+
+network_pkgs_centos8:
   - python3-libselinux
   - bridge-utils
   - iputils

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,6 @@
 ---
 network_pkgs:
-  - libselinux-python
+  - python3-libselinux
   - bridge-utils
   - iputils
 


### PR DESCRIPTION
CentOS-8-Stream brings the following differences:
- package `bridge-utils` is brought by epel repositories
- package `libselinux-python` is renamed `python3-libselinux`
- systemctl service `network` is available only after package `network-scripts` is installed (it becomes an alias for `NetworkManager`)
This PR addresses these changes without affecting the original functioning of the module.