### PR TITLE
make handler centos8 and above compatible

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,10 @@
 ---
 - name: restart network
   service: name=network state=restarted
-  when: network_allow_service_restart
+  when: network_allow_service_restart and
+        ansible_distribution_major_version | int == 7
+
+- name: restart network
+  service: name=NetworkManager state=restarted
+  when: network_allow_service_restart and
+        ansible_distribution_major_version | int >= 8


### PR DESCRIPTION
centos 8 and onward has NetworkManager as network service name. On the other hand, upto centos7 it was network. Therefore, we need to make ansible aware of that.

CCCP-4429