### PR TITLE
Improve supported distros

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,3 +11,4 @@ network_extra_bonding_module_options: ""
 network_ip_route_ephemeral: false
 network_bridge_ephemeral: false
 network_vlan_ephemeral: false
+network_service: "network"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,6 @@
 ---
 - name: restart network
-  service: name=network state=restarted
+  systemd:
+    name: "{{ network_service }}"
+    state: restarted
   when: network_allow_service_restart

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,20 +9,20 @@
 - name: Add the OS specific varibles
   include_vars: "{{ ansible_os_family }}.yml"
 
-- name: Check if we are in CentOS 8
+- name: Check if we are in RHEL8 variant
   set_fact:
-    os_centos8: "{{ ansible_facts['distribution'] == 'CentOS' and ansible_facts['distribution_major_version'] == '8' }}"
+    os_rhel8based: "{{ ansible_os_family == 'RedHat' and ansible_facts['distribution_major_version'] == '8' }}"
 
-- name: Install prerequisites for CentOS 8
+- name: Install prerequisites for RHEL8 variants
   yum:
     name: epel-release,network-scripts
     state: latest
-  when: os_centos8
+  when: os_rhel8based
 
-- name: Adjust vars in case of CentOS 8
+- name: Adjust vars in case of RHEL8 variant
   set_fact:
-    network_pkgs: "{{ network_pkgs_centos8 }}"
-  when: os_centos8
+    network_pkgs: "{{ network_pkgs_rhel8based }}"
+  when: os_rhel8based
 
 - name: Install the required  packages in Redhat derivatives
   yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,20 +9,21 @@
 - name: Add the OS specific varibles
   include_vars: "{{ ansible_os_family }}.yml"
 
-- name: Check if we are in RHEL8 variant
+- name: Check if we are in RHEL8 or RHEL9 variant
   set_fact:
-    os_rhel8based: "{{ ansible_os_family == 'RedHat' and ansible_facts['distribution_major_version'] == '8' }}"
+    os_rhel8_9based: "{{ ansible_os_family == 'RedHat' and ansible_facts['distribution_major_version'] >= '8' }}"
 
-- name: Install prerequisites for RHEL8 variants
+- name: Install prerequisites for RHEL8/RHEL9 variants
   yum:
-    name: epel-release,network-scripts
+    name: epel-release
     state: latest
-  when: os_rhel8based
+  when: os_rhel8_9based
 
-- name: Adjust vars in case of RHEL8 variant
+- name: Adjust vars in case of RHEL8/RHEL9 variant
   set_fact:
-    network_pkgs: "{{ network_pkgs_rhel8based }}"
-  when: os_rhel8based
+    network_pkgs: "{{ network_pkgs_rhel8_9based }}"
+    network_service: "NetworkManager"
+  when: os_rhel8_9based
 
 - name: Install the required  packages in Redhat derivatives
   yum:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,7 +4,7 @@ network_pkgs:
   - bridge-utils
   - iputils
 
-network_pkgs_centos8:
+network_pkgs_rhel8based:
   - python3-libselinux
   - bridge-utils
   - iputils

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,7 +4,7 @@ network_pkgs:
   - bridge-utils
   - iputils
 
-network_pkgs_rhel8based:
+network_pkgs_rhel8_9based:
   - python3-libselinux
   - bridge-utils
   - iputils


### PR DESCRIPTION
Role was supporting already CentOS8-stream, but with this change it will
support all RHEL7/8/9 variants ie. CentOS7, CentOS8-Stream, Alma8,
Rocky9 etc.
Network restarting is handled with systemd instead of legacy
init-scripts. That's because with RHEL9 variants there isn't anymore
available package which would add old init-scripts to do it old
fashioned way.