### PR TITLE
Toggle interface also when ip is assigned to bridge

### DIFF
--- a/handlers/toggle_interface.yml
+++ b/handlers/toggle_interface.yml
@@ -11,6 +11,16 @@
     - hostvars[inventory_hostname]['ansible_' + (item.1 | replace('-','_'))].ipv4.address is defined
     - hostvars[inventory_hostname]['ansible_' + (item.0.device | replace('-','_'))].ipv4.address == hostvars[inventory_hostname]['ansible_' + (item.1 | replace('-','_'))].ipv4.address
   loop: "{{ query('subelements', network_bond_interfaces, 'bond_slaves') }}"
+  register: bond_toggled
+
+- name: toggle any interface still having same ip as its bridge
+  shell: "nmcli device disconnect {{ item.1 }} && sleep 10 && nmcli device connect {{ item.1 }}"
+  when:
+    - bond_toggled.results | map(attribute='skipped') | list is all
+    - hostvars[inventory_hostname]['ansible_' + (item.0.bridge | replace('-','_'))].ipv4.address is defined
+    - hostvars[inventory_hostname]['ansible_' + (item.1 | replace('-','_'))].ipv4.address is defined
+    - hostvars[inventory_hostname]['ansible_' + (item.0.bridge | replace('-','_'))].ipv4.address == hostvars[inventory_hostname]['ansible_' + (item.1 | replace('-','_'))].ipv4.address
+  loop: "{{ query('subelements', network_bond_interfaces, 'bond_slaves') }}"
 
 - name: reapply any interface with ipv4 addr to get all configurations activated
   shell: "nmcli connection up 'System {{ item }}'"


### PR DESCRIPTION
We have few cases in which the ansible config assigns the IP not to the bond interface but to its bridge instead. In such cases, the current toggling check fails because there are no ip addresses assigned to the bond interfaces.
The change proposed in this commit checks if we have some bond slaves whose ip address is the same as the ip address assigned to the bridge of the bond. Such check is performed only if the original check is completely skipped.