### PR TITLE
Ignore bond interfaces on toggle interface handler

### DIFF
--- a/handlers/toggle_interface.yml
+++ b/handlers/toggle_interface.yml
@@ -24,6 +24,6 @@
 
 - name: reapply any interface with ipv4 addr to get all configurations activated
   shell: "nmcli connection up 'System {{ item }}'"
-  when: ansible_facts[item].ipv4.address is defined and not 'lo' == item
+  when: ansible_facts[item].ipv4.address is defined and not 'lo' == item and 'bond' not in item
   loop: "{{ ansible_interfaces }}"
 ...


### PR DESCRIPTION
Reapplying non-bond interfaces was added because routes were not applied on them. Bond interfaces are created when role is being applied which is why they could be ignored on this task.