### PR TITLE
Check if bridge is defined for the bond before using it in checks

### DIFF
--- a/handlers/toggle_interface.yml
+++ b/handlers/toggle_interface.yml
@@ -17,6 +17,7 @@
   shell: "nmcli device disconnect {{ item.1 }} && sleep 10 && nmcli device connect {{ item.1 }}"
   when:
     - bond_toggled.results | map(attribute='skipped') | list is all
+    - item.0.bridge is defined
     - hostvars[inventory_hostname]['ansible_' + (item.0.bridge | replace('-','_'))].ipv4.address is defined
     - hostvars[inventory_hostname]['ansible_' + (item.1 | replace('-','_'))].ipv4.address is defined
     - hostvars[inventory_hostname]['ansible_' + (item.0.bridge | replace('-','_'))].ipv4.address == hostvars[inventory_hostname]['ansible_' + (item.1 | replace('-','_'))].ipv4.address


### PR DESCRIPTION
We have recently refined the handler so that it would disconnect and connect any interface having the same ip as a corresponding bond interface. This works fine in the nodes that define bond interfaces, but not in the nodes that don't.
This commit adds a simple check to ensure that the interface handled is a bond that has indeed a bridge defined before going forward with further checks, which take this fact for granted.