### PR TITLE
Fix conditions for check on bridge interfaces

### DIFF
--- a/handlers/toggle_interface.yml
+++ b/handlers/toggle_interface.yml
@@ -16,7 +16,6 @@
 - name: toggle any interface still having same ip as its bridge
   shell: "nmcli device disconnect {{ item.1 }} && sleep 10 && nmcli device connect {{ item.1 }}"
   when:
-    - bond_toggled.results | map(attribute='skipped') | list is all
     - item.0.bridge is defined
     - hostvars[inventory_hostname]['ansible_' + (item.0.bridge | replace('-','_'))].ipv4.address is defined
     - hostvars[inventory_hostname]['ansible_' + (item.1 | replace('-','_'))].ipv4.address is defined
@@ -25,6 +24,6 @@
 
 - name: reapply any interface with ipv4 addr to get all configurations activated
   shell: "nmcli connection up 'System {{ item }}'"
-  when: ansible_facts[item].ipv4.address is defined and not 'lo' == item and 'bond' not in item
+  when: ansible_facts[item].ipv4.address is defined and not 'lo' == item and 'bond' not in item and 'virbr' not in item
   loop: "{{ ansible_interfaces }}"
 ...


### PR DESCRIPTION
Currently the check on bridge interfaces is performed only if no actions have been taken on the bond interfaces in the previous task. This is implemented by checking that the results obtained from the previous task all contain the 'skipped: true' flag. Nevertheless, if an action is taken in the previous task instead, then the 'skipped: true' flag is completely absent (there is no 'skipped: false'), which breaks the check.
We can obtain the same restriction by checking only the bonds for which a bridge is defined in their data. Compute nodes do not have such bridge field, and thus will be automatically excluded.
The commit also avoid to reapply the configuration for interfaces such as 'virbr0'.